### PR TITLE
[6.8] chore: replace lucene-gosen with lucene-kuromoji for Japanese tokeniz…

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ annotations = "26.0.2"
 jackson = "2.21.1"
 morfologik = "2.1.9"
 lucene = "8.11.3"
-lucene_gosen = "8.11.0"
 guava = "33.3.1-jre"
 openregex = "1.1.1"
 indriya = "1.3"
@@ -119,7 +118,7 @@ opennlp-tools = {group = "org.apache.opennlp", name = "opennlp-tools", version.r
 # lucene
 lucene-backward-codecs = {group = "org.apache.lucene", name = "lucene-backward-codecs", version.ref = "lucene"}
 lucene-core = {group = "org.apache.lucene", name = "lucene-core", version.ref = "lucene"}
-lucene-gosen = {group = "org.omegat.lucene", name = "lucene-gosen", version.ref = "lucene_gosen"}
+lucene-kuromoji = {group = "org.apache.lucene", name = "lucene-analyzers-kuromoji", version.ref = "lucene"}
 lucene-analyzers-common = {group = "org.apache.lucene", name = "lucene-analyzers-common", version.ref = "lucene"}
 lucene-queries = {group = "org.apache.lucene", name = "lucene-queries", version.ref = "lucene"}
 lucene-sandbox = {group = "org.apache.lucene", name = "lucene-sandbox", version.ref = "lucene"}

--- a/languagetool-language-modules/ja/build.gradle.kts
+++ b/languagetool-language-modules/ja/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 
 dependencies {
     implementation(libs.jetbrains.annotations)
-    implementation(variantOf(libs.lucene.gosen){ classifier("ipadic") })
+    implementation(libs.lucene.kuromoji)
     implementation(libs.icu4j)
     implementation(project(":languagetool-core"))
     testImplementation(libs.junit4)

--- a/languagetool-language-modules/ja/src/main/java/org/languagetool/tokenizers/ja/JapaneseWordTokenizer.java
+++ b/languagetool-language-modules/ja/src/main/java/org/languagetool/tokenizers/ja/JapaneseWordTokenizer.java
@@ -18,38 +18,47 @@
  */
 package org.languagetool.tokenizers.ja;
 
+import org.apache.lucene.analysis.ja.JapaneseTokenizer;
+import org.apache.lucene.analysis.ja.tokenattributes.BaseFormAttribute;
+import org.apache.lucene.analysis.ja.tokenattributes.PartOfSpeechAttribute;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.languagetool.tokenizers.Tokenizer;
+
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 
-import net.java.sen.*;
-import net.java.sen.dictionary.Token;
-
-import org.languagetool.tokenizers.Tokenizer;
 
 public class JapaneseWordTokenizer implements Tokenizer {
 
-  private final StringTagger stringTagger;
-
-  public JapaneseWordTokenizer() {
-    stringTagger = SenFactory.getStringTagger(null, false);
-  }
-
-  @Override  
+  @Override
   public List<String> tokenize(String text) {
     List<String> ret = new ArrayList<>();
-    try {
-      synchronized (stringTagger) {
-        List<Token> tokens = new ArrayList<>();
-        stringTagger.analyze(text, tokens);
-        for (Token token : tokens) {
-          String basicForm;
-          if (token.getMorpheme().getBasicForm().equalsIgnoreCase("*")) {
-            basicForm = token.getSurface();
-          } else {
-            basicForm = token.getMorpheme().getBasicForm();
-          }
-          ret.add(token.getSurface() + " " + token.getMorpheme().getPartOfSpeech() + " " + basicForm);
+
+    try (JapaneseTokenizer tokenizer = new JapaneseTokenizer(null, false, JapaneseTokenizer.Mode.NORMAL)) {
+      tokenizer.setReader(new StringReader(text));
+
+      CharTermAttribute termAtt = tokenizer.addAttribute(CharTermAttribute.class);
+      PartOfSpeechAttribute posAtt = tokenizer.addAttribute(PartOfSpeechAttribute.class);
+      BaseFormAttribute baseFormAtt = tokenizer.addAttribute(BaseFormAttribute.class);
+
+      tokenizer.reset();
+      while (tokenizer.incrementToken()) {
+        String surface = termAtt.toString();
+        String baseForm = baseFormAtt.getBaseForm();
+        if (baseForm == null || baseForm.equals("*")) {
+          baseForm = surface;
         }
+        String pos = posAtt.getPartOfSpeech();
+        if (pos == null) {
+          pos = "";
+        } else {
+          int separateIndex = pos.indexOf("-");
+          if (separateIndex != -1) {
+            pos = pos.substring(0, separateIndex);
+          }
+        }
+        ret.add(surface + " " + pos + " " + baseForm);
       }
     } catch (Exception e) {
       return ret;

--- a/languagetool-language-modules/ja/src/main/resources/org/languagetool/rules/ja/grammar.xml
+++ b/languagetool-language-modules/ja/src/main/resources/org/languagetool/rules/ja/grammar.xml
@@ -5,7 +5,7 @@
 <!--
 Japanese Grammar and Typo Rules file for LanguageTool
 -->
-<rules xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xs="http://www.w3.org/2001/XMLSchema" lang="ja" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd">
+<rules xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" lang="ja" xsi:noNamespaceSchemaLocation="../../../../../../../../../languagetool-core/src/main/resources/org/languagetool/rules/rules.xsd">
 	<!-- ============================== -->
 	<!-- 文法 -->
 	<!-- ============================== -->
@@ -319,8 +319,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 			<pattern>
 				<token>降っ</token>
 				<token>た</token>
-				<token>な</token>
-				<token>い</token>
+				<token>ない</token>
 			</pattern>
 			<message>文法ミスがあります。<suggestion>降らなかった</suggestion>の間違いです。</message>
 			<example correction="降らなかった"><marker>降ったない</marker></example>
@@ -473,10 +472,10 @@ Japanese Grammar and Typo Rules file for LanguageTool
 			<pattern>
 				<token postag="名詞.*" postag_regexp="yes"></token>
 				<marker>
-					<token postag="助詞-連体化">の</token>
+					<token postag="助詞">の</token>
 				</marker>
-				<token postag="名詞-サ変接続">表示</token>
-				<token inflected="yes" postag="動詞-自立">する</token>
+				<token postag="名詞">表示</token>
+				<token inflected="yes" postag="動詞">する</token>
 			</pattern>
 			<message>目的語を表すには<suggestion>を</suggestion>を使用します。</message>
 			<example correction="を">詳細<marker>の</marker>表示する</example>
@@ -617,8 +616,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="SIITEHAKOTOWOSISONNZURU" name="強しては事を仕損ずる">
 			<pattern>
-				<token>強</token>
-				<token>し</token>
+				<token>強し</token>
 				<token>て</token>
 				<token>は</token>
 				<token regexp="yes">事|こと</token>
@@ -653,7 +651,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 			<pattern>
 				<token>腹</token>
 				<token>立</token>
-				<token>だし</token>
+				<token>だ</token>
+                <token>し</token>
 				<token>い</token>
 			</pattern>
 			<message>文法ミスがあります。<suggestion>腹立たしい</suggestion>の間違いです。</message>
@@ -676,7 +675,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 			<pattern>
 				<token regexp="yes">待ち|まち</token>
 				<token>どう</token>
-				<token regexp="yes">しい|しく</token>
+                <token>し</token>
+				<token regexp="yes">い|く</token>
 			</pattern>
 			<message>文法ミスがあります。<suggestion>待ちどおしい</suggestion>の間違いです。</message>
 			<example correction="待ちどおしい">デートが<marker>待ちどうしい</marker>。</example>
@@ -722,10 +722,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="YAMUOEZU" name="やむおえず">
 			<pattern>
-				<token>やむ</token>
-				<token>お</token>
-				<token>え</token>
-				<token>ず</token>
+				<token>や</token>
+				<token>むおえず</token>
 			</pattern>
 			<message>文法ミスがあります。<suggestion>やむをえず</suggestion>の間違いです。</message>
 			<example correction="やむをえず"><marker>やむおえず</marker>。</example>
@@ -758,8 +756,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="ZURAI" name="ずらい">
 			<pattern>
-				<token>ず</token>
-				<token regexp="yes">らい|らく</token>
+				<token>ずら</token>
+				<token regexp="yes">い|く</token>
 			</pattern>
 			<message>文法ミスがあります。<suggestion>づらい</suggestion>の間違いです。</message>
 			<example correction="づらい">読み<marker>ずらい</marker>字</example>
@@ -844,13 +842,6 @@ Japanese Grammar and Typo Rules file for LanguageTool
 			</pattern>
 			<message>誤字があります。<suggestion>一念発起</suggestion>の間違いです。</message>
 			<example correction="一念発起"><marker>一念奮起</marker>しよう。</example>
-		</rule>
-		<rule id="ISSYOKENMEI" name="一所懸命">
-			<pattern>
-				<token>一所懸命</token>
-			</pattern>
-			<message>誤字があります。<suggestion>一生懸命</suggestion>の間違いです。</message>
-			<example correction="一生懸命">大学の課題<marker>一所懸命</marker>に行う。</example>
 		</rule>
 		<rule id="ISSOKUSYOKUHATU" name="一即触発">
 			<pattern>
@@ -954,7 +945,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 			<pattern>
 				<token regexp="yes">良い|よい</token>
 				<token regexp="yes">事|こと</token>
-				<token>だらけ</token>
+                <token>だら</token>
+                <token>け</token>
 			</pattern>
 			<message>誤字があります。<suggestion>良い事尽くめ</suggestion>の間違いです。</message>
 			<example correction="良い事尽くめ"><marker>良い事だらけ</marker></example>
@@ -1271,7 +1263,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		<rule id="KUTISAKISANNZUNN" name="口先三寸">
 			<pattern>
 				<token>口先</token>
-				<token>三寸</token>
+                <token>三</token>
+                <token>寸</token>
 			</pattern>
 			<message>誤字があります。<suggestion>舌先三寸</suggestion>の間違いです。</message>
 			<example correction="舌先三寸"><marker>口先三寸</marker>。</example>
@@ -1332,8 +1325,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="SUTORI-TOKINGU" name="ストリートキング">
 			<pattern>
-				<token>ストリート</token>
-				<token>キング</token>
+				<token>ストリートキング</token>
 			</pattern>
 			<message>誤字があります。<suggestion>ストリーキング</suggestion>の間違いです。</message>
 			<example correction="ストリーキング"><marker>ストリートキング</marker></example>
@@ -1644,18 +1636,6 @@ Japanese Grammar and Typo Rules file for LanguageTool
 	<!-- ============================== -->
 
 	<category id="CAT3" name="誤変換">
-		<rule id="ATARAZUTOMOTOOKARAZU" name="当たらずとも遠からず">
-			<pattern>
-				<token>当たら</token>
-				<token>ず</token>
-				<token>と</token>
-				<token>も</token>
-				<token regexp="yes">遠から|とおから</token>
-				<token>ず</token>
-			</pattern>
-			<message>誤変換です。<suggestion>中らずといえども遠からず</suggestion>の間違いです</message>
-			<example correction="中らずといえども遠からず">彼の意見は<marker>当たらずとも遠からず</marker>だ。</example>
-		</rule>
 		<rule id="ASAZUKE" name="浅漬け">
 			<pattern>
 				<token>浅</token>
@@ -1918,7 +1898,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="IPPENNTOU" name="一遍倒">
 			<pattern>
-				<token>一遍</token>
+                <token>一</token>
+                <token>遍</token>
 				<token>倒</token>
 			</pattern>
 			<message>誤変換です。<suggestion>一辺倒</suggestion>の間違いです。</message>
@@ -2595,7 +2576,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="KOTOBADUKAI" name="言葉遣い">
 			<pattern>
-				<token regexp="yes">言葉遣い|ことば遣い</token>
+                <token regexp="yes">言葉|ことば</token>
+                <token>遣い</token>
 			</pattern>
 			<message>誤変換です。<suggestion>言葉使い</suggestion>の間違いです。</message>
 			<example correction="言葉使い"><marker>言葉遣い</marker>。</example>
@@ -2670,13 +2652,12 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="KAKAADENNKA" name="かかあ殿下">
 			<pattern>
-				<token>か</token>
-				<token>か</token>
+				<token>かか</token>
 				<token>あ</token>
 				<token>殿下</token>
 			</pattern>
-			<message>誤変換です。<suggestion>嚊天下</suggestion>の間違いです。</message>
-			<example correction="嚊天下"><marker>かかあ殿下</marker>。</example>
+			<message>誤変換です。<suggestion>かかあ天下</suggestion>の間違いです。</message>
+			<example correction="かかあ天下"><marker>かかあ殿下</marker>。</example>
 		</rule>
 		<rule id="GAKAI" name="瓦壊">
 			<pattern>
@@ -2790,7 +2771,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		<rule id="KIMAJIME" name="気真面目">
 			<pattern>
 				<token>気</token>
-				<token>真面目</token>
+                <token>真面目</token>
 			</pattern>
 			<message>誤変換です。<suggestion>生真面目</suggestion>の間違いです。</message>
 			<example correction="生真面目"><marker>気真面目</marker>。</example>
@@ -3030,8 +3011,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		<rule id="KOUSEIOSORUBESI" name="後世おそるべし">
 			<pattern>
 				<token>後世</token>
-				<token>お</token>
-				<token>そる</token>
+				<token>おそ</token>
+				<token>る</token>
 				<token>べし</token>
 			</pattern>
 			<message>誤変換です。<suggestion>後生畏る可し</suggestion>の間違いです。</message>
@@ -3139,8 +3120,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="SAIKOUTYOU" name="最高調">
 			<pattern>
-				<token>最高</token>
-				<token>調</token>
+				<token>最</token>
+				<token>高調</token>
 			</pattern>
 			<message>誤変換です。<suggestion>最高潮</suggestion>の間違いです。</message>
 			<example correction="最高潮"><marker>最高調</marker></example>
@@ -4078,7 +4059,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		<rule id="TOORIIPPENN" name="通り一辺">
 			<pattern>
 				<token>通り</token>
-				<token>一辺</token>
+				<token>一</token>
+                <token>辺</token>
 			</pattern>
 			<message>誤変換です。<suggestion>通り一遍</suggestion>の間違いです。</message>
 			<example correction="通り一遍"><marker>通り一辺</marker>の言葉。</example>
@@ -4148,8 +4130,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		<rule id="TEITARAKU" name="低たらく">
 			<pattern>
 				<token>低</token>
-				<token>たら</token>
-				<token>く</token>
+				<token>た</token>
+				<token>らく</token>
 			</pattern>
 			<message>誤変換です。<suggestion>体たらく</suggestion>の間違いです。</message>
 			<example correction="体たらく"><marker>低たらく</marker>。</example>
@@ -4345,8 +4327,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		<rule id="BANNJIKYUUSU" name="万事窮す">
 			<pattern>
 				<token>万事</token>
-				<token>窮</token>
-				<token>す</token>
+				<token>窮す</token>
 			</pattern>
 			<message>誤変換です。<suggestion>万事休す</suggestion>の間違いです。</message>
 			<example correction="万事休す"><marker>万事窮す</marker>。</example>
@@ -4571,7 +4552,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 			<pattern>
 				<token>水</token>
 				<token>水</token>
-				<token>しい</token>
+                <token>し</token>
+                <token>い</token>
 			</pattern>
 			<message>誤変換です。<suggestion>瑞瑞しい</suggestion>の間違いです。</message>
 			<example correction="瑞瑞しい"><marker>水水しい</marker>。</example>
@@ -4985,7 +4967,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="GISINANKIWOIDAKU" name="疑心暗鬼を抱く">
 			<pattern>
-				<token>疑心暗鬼</token>
+                <token>疑心暗鬼</token>
 				<token skip="10">を</token>
 				<token regexp="yes" inflected="yes">抱く|いだく</token>
 			</pattern>
@@ -5061,9 +5043,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 			<pattern>
 				<token>権力</token>
 				<token>に</token>
-				<token>お</token>
-				<token>も</token>
-				<token>ね</token>
+				<token>おもね</token>
 				<token>て</token>
 			</pattern>
 			<message><suggestion>権力におもねって</suggestion>の間違いです</message>
@@ -5161,7 +5141,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 				<token>を</token>
 				<token>知れ</token>
 				<token>ば</token>
-				<token>百戦</token>
+                <token>百</token>
+                <token>戦</token>
 				<token>殆</token>
 				<token>から</token>
 				<token>ず</token>
@@ -5348,7 +5329,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 				<token>食う</token>
 				<token>虫</token>
 				<token skip="10">も</token>
-				<token>好き好き</token>
+                <token>好き</token>
+                <token>好き</token>
 			</pattern>
 			<message>連合関係がおかしいです。<suggestion>蓼食う虫も好き好き</suggestion>の間違いです。</message>
 			<example correction="蓼食う虫も好き好き"><marker>田で食う虫も好き好き</marker>。</example>
@@ -5666,15 +5648,14 @@ Japanese Grammar and Typo Rules file for LanguageTool
 			<message>重複しています。<suggestion>血痕</suggestion>の間違いです。</message>
 			<example correction="血痕"><marker>血痕の跡</marker>。</example>
 		</rule>
-		<rule id="KANETEKARANOKENNANN" name="予かねてからの懸案">
+		<rule id="KANETEKARANOKENNANN" name="予てからの懸案">
 			<pattern>
-				<token>予</token>
-				<token>かねてから</token>
+				<token regexp="yes">予てから|かねてから</token>
 				<token>の</token>
 				<token>懸案</token>
 			</pattern>
-			<message>重複しています。<suggestion>懸案</suggestion>の間違いです。</message>
-			<example correction="懸案"><marker>予かねてからの懸案</marker>。</example>
+			<message>重複しています。<suggestion>かねての懸案</suggestion>の間違いです。</message>
+			<example correction="かねての懸案"><marker>かねてからの懸案</marker>。</example>
 		</rule>
 		<rule id="IMANOGENNJOU" name="今の現状">
 			<pattern>
@@ -5888,7 +5869,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="KAHANNSUUWOKOERU" name="過半数を超える">
 			<pattern>
-				<token>過半数</token>
+                <token>過半数</token>
 				<token>を</token>
 				<token>超える</token>
 			</pattern>
@@ -5913,7 +5894,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="KIRISUTOKYOUNOBOKUSI" name="キリスト教の牧師">
 			<pattern>
-				<token>キリスト教</token>
+				<token>キリスト</token>
+                <token>教</token>
 				<token>の</token>
 				<token>牧師</token>
 			</pattern>
@@ -5940,7 +5922,8 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		<rule id="MADAMIKAIKETU" name="まだ未解決">
 			<pattern>
 				<token>まだ</token>
-				<token>未解決</token>
+                <token>未</token>
+                <token>解決</token>
 			</pattern>
 			<message>重複しています。<suggestion>未解決</suggestion>の間違いです。</message>
 			<example correction="未解決"><marker>まだ未解決</marker></example>
@@ -6025,8 +6008,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		</rule>
 		<rule id="KURERU" name="来れる">
 			<pattern>
-				<token regexp="yes">来|こ</token>
-				<token inflected="yes">れる</token>
+				<token regexp="yes">来れる|これる</token>
 			</pattern>
 			<message>ら抜き言葉があります。<suggestion>来られる</suggestion>の間違いです。</message>
 			<url>http://www3.kcn.ne.jp/~jarry/keig/c01c05.htm</url>
@@ -6353,8 +6335,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		<rule id="OKASASERU" name="置かさせる">
 			<pattern>
 				<token regexp="yes">置か|おか</token>
-				<token>さ</token>
-				<token inflected="yes">せる</token>
+				<token inflected="yes">させる</token>
 			</pattern>
 			<message>さ入れ言葉があります。<suggestion>置かせる</suggestion>の間違いです。</message>
 			<url>http://www3.kcn.ne.jp/~jarry/keig/c01c06.htm</url>
@@ -6363,8 +6344,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		<rule id="ARUKASASERU" name="歩かさせる">
 			<pattern>
 				<token regexp="yes">歩か|あるか</token>
-				<token>さ</token>
-				<token inflected="yes">せる</token>
+				<token inflected="yes">させる</token>
 			</pattern>
 			<message>さ入れ言葉があります。<suggestion>歩かせる</suggestion>の間違いです。</message>
 			<url>http://www3.kcn.ne.jp/~jarry/keig/c01c06.htm</url>
@@ -6373,8 +6353,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		<rule id="TORASASERU" name="取らさせる">
 			<pattern>
 				<token regexp="yes">取ら|とら</token>
-				<token>さ</token>
-				<token inflected="yes">せる</token>
+				<token inflected="yes">させる</token>
 			</pattern>
 			<message>さ入れ言葉があります。<suggestion>取らせる</suggestion>の間違いです。</message>
 			<url>http://www3.kcn.ne.jp/~jarry/keig/c01c06.htm</url>
@@ -6383,8 +6362,7 @@ Japanese Grammar and Typo Rules file for LanguageTool
 		<rule id="YASUMASASERU" name="休まさせる">
 			<pattern>
 				<token regexp="yes">休ま|やすま</token>
-				<token>さ</token>
-				<token inflected="yes">せる</token>
+				<token inflected="yes">させる</token>
 			</pattern>
 			<message>さ入れ言葉があります。<suggestion>休ませる</suggestion>の間違いです。</message>
 			<url>http://www3.kcn.ne.jp/~jarry/keig/c01c06.htm</url>

--- a/languagetool-language-modules/ja/src/test/java/org/languagetool/tagging/ja/JapaneseTaggerTest.java
+++ b/languagetool-language-modules/ja/src/test/java/org/languagetool/tagging/ja/JapaneseTaggerTest.java
@@ -39,11 +39,11 @@ public class JapaneseTaggerTest {
   @Test
   public void testTagger() throws IOException {
     TestTools.myAssert("これは簡単なテストです。",
-        "これ/[これ]名詞-代名詞-一般 -- は/[は]助詞-係助詞 -- 簡単/[簡単]名詞-形容動詞語幹 -- な/[だ]助動詞 -- テスト/[テスト]名詞-サ変接続 -- です/[です]助動詞 -- 。/[。]記号-句点", tokenizer, tagger);
+        "これ/[これ]名詞 -- は/[は]助詞 -- 簡単/[簡単]名詞 -- な/[だ]助動詞 -- テスト/[テスト]名詞 -- です/[です]助動詞 -- 。/[。]記号", tokenizer, tagger);
     TestTools.myAssert("私は眠い。",
-        "私/[私]名詞-代名詞-一般 -- は/[は]助詞-係助詞 -- 眠い/[眠い]形容詞-自立 -- 。/[。]記号-句点", tokenizer, tagger);
+        "私/[私]名詞 -- は/[は]助詞 -- 眠い/[眠い]形容詞 -- 。/[。]記号", tokenizer, tagger);
     TestTools.myAssert("とても冷たい飲み物。",
-        "とても/[とても]副詞-助詞類接続 -- 冷たい/[冷たい]形容詞-自立 -- 飲み物/[飲み物]名詞-一般 -- 。/[。]記号-句点", tokenizer, tagger);
+        "とても/[とても]副詞 -- 冷たい/[冷たい]形容詞 -- 飲み物/[飲み物]名詞 -- 。/[。]記号", tokenizer, tagger);
   }
   
 

--- a/languagetool-language-modules/ja/src/test/java/org/languagetool/tokenizers/ja/JapaneseWordTokenizerTest.java
+++ b/languagetool-language-modules/ja/src/test/java/org/languagetool/tokenizers/ja/JapaneseWordTokenizerTest.java
@@ -31,10 +31,10 @@ public class JapaneseWordTokenizerTest {
   public void testTokenize() {
     JapaneseWordTokenizer w = new JapaneseWordTokenizer();
     List<String> testList = w.tokenize("これはペンです。");
-    assertEquals(testList.size(), 5);
-    assertEquals("[これ 名詞-代名詞-一般 これ, は 助詞-係助詞 は, ペン 名詞-一般 ペン, です 助動詞 です, 。 記号-句点 。]", testList.toString());
+    assertEquals(5, testList.size());
+    assertEquals("[これ 名詞 これ, は 助詞 は, ペン 名詞 ペン, です 助動詞 です, 。 記号 。]", testList.toString());
     testList = w.tokenize("私は「うん、そうだ」と答えた。");
-    assertEquals(testList.size(), 12);
-    assertEquals("[私 名詞-代名詞-一般 私, は 助詞-係助詞 は, 「 記号-括弧開 「, うん 感動詞 うん, 、 記号-読点 、, そう 副詞-助詞類接続 そう, だ 助動詞 だ, 」 記号-括弧閉 」, と 助詞-格助詞-引用 と, 答え 動詞-自立 答える, た 助動詞 た, 。 記号-句点 。]", testList.toString());
+    assertEquals(12, testList.size());
+    assertEquals("[私 名詞 私, は 助詞 は, 「 記号 「, うん 感動詞 うん, 、 記号 、, そう 副詞 そう, だ 助動詞 だ, 」 記号 」, と 助詞 と, 答え 動詞 答える, た 助動詞 た, 。 記号 。]", testList.toString());
   }
 }


### PR DESCRIPTION
…ation

- Update to lucene-kuromoji for improved and maintained tokenizer support.
- Remove deprecated lucene-gosen dependency.
- Adjust JapaneseWordTokenizer to use Kuromoji library.
- Optimize grammar.xml by combining tokens and removing redundancies.
- Update associated test cases to align with the Kuromoji-based tokenizer changes.